### PR TITLE
tmp: verify clean T11 workflow consistency

### DIFF
--- a/.agents/skills/sce-change-to-plan/SKILL.md
+++ b/.agents/skills/sce-change-to-plan/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.

--- a/.agents/skills/sce-change-to-plan/references/context-load.md
+++ b/.agents/skills/sce-change-to-plan/references/context-load.md
@@ -61,7 +61,7 @@ sentence.
 
 ## 1.5 Return the brief
 
-Set exactly one internal state:
+Return one internal result with one of these statuses:
 
 - `loaded`
 - `bootstrap_required`
@@ -69,7 +69,7 @@ Set exactly one internal state:
 Report facts the workflow can act on. A brief that only lists file paths has
 moved no knowledge.
 
-Record only the internal state. Do not add explanatory prose before or after it.
+Return only the internal result. Do not add explanatory prose before or after it.
 
 Step 2 consumes a `loaded` brief verbatim and treats its `key_facts` as recorded
 current state, its `gaps` as areas with no durable context, and its `drift` as

--- a/.agents/skills/sce-change-to-plan/references/output.md
+++ b/.agents/skills/sce-change-to-plan/references/output.md
@@ -48,7 +48,7 @@ candidate plan paths and explain that naming one candidate resolves it.
 
 This plan is a draft. State a correction and it will be updated.
 
-Next up:
+Next step:
 
 {next-task-id} — {next-task-title}
 
@@ -71,17 +71,17 @@ This is chat output, not a file. Nothing here is written to the plan.
 
 Path: {plan.path}
 
-## Summary:
+## Summary
 {plan summary}
 
-## Tasks:
+## Tasks
 1. {task.id} — {task.title}
 2. {task.id} — {task.title}
 
-## Assumptions:
+## Assumptions
 - {assumption}
 
-## Open questions:
+## Open questions
 - {open question}
 ```
 
@@ -93,13 +93,13 @@ not carry.
 - `Plan:` — `plan.name`. Append ` (updated)` when `plan.action` is `updated`.
   Render nothing extra when it is `created`.
 - `Path:` — `plan.path`, exactly as returned, so it stays runnable.
-- `Summary:` — `summary`, as prose. This is the only place the reader learns
+- `Summary` — `summary`, as prose. This is the only place the reader learns
   what the plan actually does, so never omit it and never replace it with a
   restatement of the task titles.
-- `Tasks:` — one numbered line per entry in `tasks`, in plan order. Append
+- `Tasks` — one numbered line per entry in `tasks`, in plan order. Append
   ` (done)` to any task whose `status` is `done`.
-- `Assumptions:` — one line per entry in `assumptions`.
-- `Open questions:` — one line per entry in `open_questions`.
+- `Assumptions` — one line per entry in `assumptions`.
+- `Open questions` — one line per entry in `open_questions`.
 
 ## Empty sections
 
@@ -109,14 +109,14 @@ explicit `None.` confirms nothing is pending.
 When `assumptions` is empty:
 
 ```
-## Assumptions:
+## Assumptions
 - None.
 ```
 
 When `open_questions` is absent:
 
 ```
-## Open questions:
+## Open questions
 - None.
 ```
 
@@ -137,16 +137,16 @@ When `open_questions` is absent:
 
 Path: context/plans/red-sce-banner.md
 
-## Summary:
-Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Colour-disabled output is unchanged, and no other help surface is affected.
+## Summary
+Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Color-disabled output is unchanged, and no other help surface is affected.
 
-## Tasks:
+## Tasks
 1. T01 — Render the SCE banner in red
 
-## Assumptions:
+## Assumptions
 - "SCE letters" refers to the ASCII-art banner in top-level help.
 - Red is uniform terminal red when colors are enabled; plain ASCII remains unchanged otherwise.
 
-## Open questions:
+## Open questions
 - None.
 ```

--- a/.agents/skills/sce-change-to-plan/references/plan-authoring.md
+++ b/.agents/skills/sce-change-to-plan/references/plan-authoring.md
@@ -28,7 +28,7 @@ responsibility.
 
 The context brief is the durable memory this plan starts from. Treat its
 `key_facts` as recorded current state, its `gaps` as areas with no durable
-context, and its `drift` as context the code has already outrun.
+context, and its `drift` as recorded context that no longer matches the code.
 
 When no brief is supplied, load the context named by the change request before
 authoring, and follow the selection discipline in *Inspect relevant context*.
@@ -178,13 +178,13 @@ exactly. For revisions, apply its `Updating an existing plan` rules.
 
 ## 2.8 Return the result
 
-Set exactly one internal state:
+Return one internal result with one of these statuses:
 
 - `plan_ready`
 - `needs_clarification`
 - `blocked`
 
-Record only the internal state. Do not add explanatory prose before or after it.
+Return only the internal result. Do not add explanatory prose before or after it.
 
 A `plan_ready` result always names the next task in `next_task`, and carries the
 `total_tasks` count and any open questions the summary needs. Step 3 renders those
@@ -192,29 +192,13 @@ without recomputing them.
 
 ## Plan authoring tone
 
-Every question and open question this phase writes is read by the user. Write
-them the way a senior engineer talks in review: direct, specific, and unbothered
-by the possibility of being unwelcome.
+Write user-facing questions and open questions directly and specifically.
 
-- Ask about the thing that actually worries you, not a safer neighbouring thing.
-  A question you would not bother asking a colleague is not worth the user's
-  attention either.
-- State a doubt as a doubt. "I do not think this is worth the two tasks it
-  costs, because X" is useful. "It may be worth considering whether this aligns
-  with broader goals" is noise.
-- Name the alternative you have in mind. A challenge with no proposal behind it
-  is just friction.
-- Do not open with praise, do not close with reassurance, and do not apologize
-  for asking. Do not pad a doubt with hedges to make it land more gently.
-- Be persistent, not repetitive. Ask once, plainly, and let it stand; do not
-  restate the same doubt in three shapes to give it more weight.
-- Being disagreeable is not the goal. Being easy to agree with is the failure
-  mode. A plan the user waves through without reading has cost them nothing and
-  bought them nothing.
-
-When the user overrules a doubt, record it and move on. Do not relitigate a
-decision the user has made, and do not smuggle the objection back in as a
-constraint, a non-goal, or a task.
+- Ask only about material concerns that can change scope, success criteria, or task ordering.
+- State the concern and the concrete evidence for it.
+- Name a smaller or safer alternative when one is known.
+- Do not invent concerns, add praise or reassurance, or repeat the same concern in several forms.
+- When the user overrules a concern, record the decision and continue. Do not reintroduce it as a constraint, non-goal, or task.
 
 ## Plan authoring boundaries
 

--- a/.agents/skills/sce-change-to-plan/references/plan-template.md
+++ b/.agents/skills/sce-change-to-plan/references/plan-template.md
@@ -146,9 +146,9 @@ invent one: `None.` is the expected answer for a well-specified change.}
 
 - The last task in the stack is an ordinary implementation task. Do not author a
   trailing "validation and cleanup" task.
-- Final validation, cleanup, and success-criteria verification are run by
-  `/validate` from the `Acceptance criteria` section after the last task
-  completes.
+- Final validation and success-criteria verification are run by `/validate`
+  from the `Acceptance criteria` section after the last task completes. Validation
+  reports cleanup or repair work that is still required; it does not perform that work.
 - Do not author a task whose only purpose is running the full check suite,
   verifying durable context, or removing scaffolding.
 - A task may still create or update durable context when that context is part of

--- a/.agents/skills/sce-commit/SKILL.md
+++ b/.agents/skills/sce-commit/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.
@@ -99,14 +99,14 @@ Run `git diff --cached --quiet`. A zero exit status means nothing is staged.
 When nothing is staged, stop with the **No staged changes** layout from
 `references/output.md`.
 
-Do not stage anything. Do not proceed to the skill.
+Do not stage anything. Do not proceed to the phase.
 
 #### 2. Request one commit message
 
 Read `references/atomic-commit.md`, then run the **Atomic commit phase** with
 `mode: bypass` and the commit context.
 
-Bypass mode is the skill's contract for producing exactly one message. Do not
+Bypass mode is the phase's contract for producing exactly one message. Do not
 restate its overrides here; the **Atomic commit phase** owns them.
 
 Branch on `status`:
@@ -115,7 +115,7 @@ Branch on `status`:
 
 `bypass_message` -> Continue to the next step.
 
-The skill never returns `proposal` in bypass mode. Treat a `proposal` result as
+The phase never returns `proposal` in bypass mode. Treat a `proposal` result as
 a contract violation: report it and stop without committing.
 
 #### 3. Execute exactly one commit

--- a/.agents/skills/sce-commit/references/atomic-commit.md
+++ b/.agents/skills/sce-commit/references/atomic-commit.md
@@ -1,4 +1,4 @@
-# SCE Atomic Commit
+# Atomic commit phase
 
 ## Purpose
 
@@ -8,8 +8,8 @@ Write messages matching:
 
 `references/commit-message-style.md`
 
-Committing is not this skill's job. The invoking `/commit` workflow decides
-whether a returned message is committed, and it is the only thing that runs
+This phase does not commit. The invoking `/commit` workflow decides
+whether a returned message is committed, and it is the only part that runs
 `git commit`.
 
 ## Input
@@ -147,7 +147,7 @@ Do not:
 
 ## Completion
 
-The skill is complete after:
+The phase is complete after:
 
 - The staged diff was read, or reading it failed and was reported.
 - Messages were written for every staged file, or a blocker prevented it.

--- a/.agents/skills/sce-handover/SKILL.md
+++ b/.agents/skills/sce-handover/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.

--- a/.agents/skills/sce-handover/references/handover-template.md
+++ b/.agents/skills/sce-handover/references/handover-template.md
@@ -1,8 +1,10 @@
+# Handover document format
+
 The Markdown document writer mode creates under
 `context/handovers/{name}.md`. This is the persisted file's content, distinct
 from the terminal response defined in `references/output.md`.
 
-### Layout
+## Template
 
 ```markdown
 # Handover: {plan name or short session topic}
@@ -35,9 +37,9 @@ enough to act on directly.}
   `None.`}
 ```
 
-### Completeness contract
+## Completeness contract
 
-- The first four `##` sections shown in **Layout** are required and must appear
+- The first four `##` sections shown in **Template** are required and must appear
   in that order.
 - Each required section's content, up to the next `##` heading or the end of the
   file, must contain non-whitespace content. An empty list marker, unreplaced
@@ -47,10 +49,10 @@ enough to act on directly.}
 - Writer mode must satisfy this contract before reporting success; loader mode
   validates the same contract before presenting a handover.
 
-### Rules
+## Rules
 
-- Include `Plan` and `Task` only when the session was working one identifiable
-  plan task; omit them rather than guessing.
+- Include `Plan` when one plan is known. Include `Task` only when one task is
+  known. Omit either field rather than guessing its value.
 - Keep `Assumptions` scoped to details actually labeled as inferred elsewhere
   in the document; do not duplicate confirmed facts here.
 - Describe durable state useful to a future session, not a transcript of this

--- a/.agents/skills/sce-handover/references/output.md
+++ b/.agents/skills/sce-handover/references/output.md
@@ -83,7 +83,7 @@ This handover has been presented for continuation only. No file was edited, no
 plan task was marked complete, and the recommended next step was not started.
 ```
 
-# Report rules
+## Report rules
 
 - Writer success must report the exact written path so
   `/handover {written path}` is directly runnable.

--- a/.agents/skills/sce-next-task/SKILL.md
+++ b/.agents/skills/sce-next-task/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command except `sce-decision`,
@@ -81,7 +81,7 @@ Branch on the outcome:
 
 `synced` | `no_context_change` -> Re-invoke the **Plan review phase** with the same `plan-name-or-path` and, when present, `task-id` to resume normal task selection.
 
-`plan_complete` -> Render the **Plan already complete** layout from `references/output.md`. Stop.
+`plan_complete` -> Render the **Implementation complete** layout from `references/output.md`. Stop.
 
 `ready` -> Pass the complete readiness result to the **Task execution phase**.
 
@@ -120,10 +120,9 @@ Branch on the execution result.
 ### 3. Synchronize context
 
 Read `references/context-sync.md`, then run the **Task context synchronization
-phase** with the complete `complete` result returned by the **Task execution
-phase**.
+phase** with the task execution result whose `status` is `complete`.
 
-Pass that `complete` result verbatim as the authoritative live handoff to the
+Pass that result unchanged as the authoritative live handoff to the
 **Task context synchronization phase**. Do not restate, summarize, or reconstruct it.
 
 This phase verifies the five root context files on every invocation, whatever the
@@ -140,7 +139,7 @@ Branch on the synchronization result.
 
 Do not select another task. Stop.
 
-`synced` | `no_context_change` -> Print out the report the **Task context synchronization phase** returned. Continue to the next step.
+`synced` | `no_context_change` -> Render the Markdown report returned by the **Task context synchronization phase** unchanged. Continue to the next step.
 
 ### 4. Determine the continuation
 

--- a/.agents/skills/sce-next-task/references/context-sync.md
+++ b/.agents/skills/sce-next-task/references/context-sync.md
@@ -7,7 +7,7 @@ plan state.
 
 Input: either the complete `complete` result from the task execution phase
 (same-session), passed verbatim, or the plan path and task ID a plan-review
-recovery step resolved for a `blocked` task, together with that task's own
+recovery step resolved for a completed task with unresolved context synchronization, together with that task's own
 completed record — read directly from the plan — and its persisted `Context
 synchronization blocker` when present (cross-session retry). Whichever was
 supplied is authoritative; this phase consumes it without redefining its shape.

--- a/.agents/skills/sce-next-task/references/output.md
+++ b/.agents/skills/sce-next-task/references/output.md
@@ -8,7 +8,7 @@ Present the selected task, then each issue's problem, impact, and required
 decision. If plan resolution is ambiguous, list candidate paths and
 `/next-task {candidate-path}`. State whether another task remains executable.
 
-## Plan already complete
+## Implementation complete
 
 ```markdown
 -------------------------------------

--- a/.agents/skills/sce-validate/SKILL.md
+++ b/.agents/skills/sce-validate/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.
@@ -50,7 +50,7 @@ Pass the plan name or path to the **Validation phase** unmodified. Do not restat
 summarize, or pre-scope it.
 
 Every `{plan-path}` and `{candidate-path}` emitted anywhere in this workflow is
-the path carried by the **Validation phase** in its Markdown result (`Plan:`, or a
+the path carried by the **Validation phase** in its Markdown report (`Plan:`, or a
 candidate path), so every emitted command is directly runnable.
 
 For example: `$sce-validate my-plan`.

--- a/.agents/skills/sce-validate/references/validation.md
+++ b/.agents/skills/sce-validate/references/validation.md
@@ -1,4 +1,4 @@
-# SCE Validation
+# Validation phase
 
 ## Purpose
 
@@ -79,8 +79,7 @@ validation.
 
 When a check fails, record the failure and continue gathering evidence. Do not
 modify tests, application code, or configuration to make a check pass. Final
-validation measures the finished work; repair belongs to a later work session,
-not this skill.
+validation measures the finished work; repair belongs to a normal work session outside this phase.
 
 Never report a check as passed unless it ran successfully or the authorized
 inspection confirmed the criterion.
@@ -102,9 +101,9 @@ Do not reopen completed tasks, rewrite task evidence, or change the task stack.
 
 For `blocked`, leave the plan file unchanged.
 
-### 6. Return the Markdown result
+### 6. Return the Markdown report
 
-Return exactly one Markdown result:
+Return exactly one Markdown report:
 
 - `validated` when every acceptance criterion is met, required full validation
   passed, and the Validation Report was written.
@@ -141,12 +140,12 @@ The phase is complete after:
 - One plan was resolved, or resolution failed and was reported.
 - Implementation completeness was checked.
 - Validation ran to a terminal state, or a blocker prevented it.
-- One valid Markdown result matching the **Validation Result** section below in this file was
+- One valid Markdown report matching the **Validation Result** section below in this file was
   returned.
 
 
 
-# Validation Result
+# Validation report
 
 Return only one completed Markdown report using the applicable variant below.
 Do not include unused sections, placeholders, YAML, or a fenced code block.
@@ -158,10 +157,10 @@ The `Status` value must be exactly one of:
 - `blocked`
 
 The plan-file `## Validation Report` section is written separately using
-`references/validation-report.md`. This file is the skill's return value to the
+`references/validation-report.md`. This file is the phase's return value to the
 invoking workflow.
 
-## Validated variant
+## Validated report
 
 # Validation Report
 
@@ -192,7 +191,7 @@ Omit this section when unnecessary.}
 
 ---
 
-## Failed variant
+## Failed report
 
 This variant is a session handoff. Another agent or a later session must be
 able to act from it alone. Write it as a prompt the user can paste forward, not
@@ -256,7 +255,7 @@ returns `validated`.
 
 ---
 
-## Blocked variant
+## Blocked report
 
 # Validation blocked
 

--- a/.claude/skills/sce-change-to-plan/SKILL.md
+++ b/.claude/skills/sce-change-to-plan/SKILL.md
@@ -11,10 +11,10 @@ compatibility: claude
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.

--- a/.claude/skills/sce-change-to-plan/references/context-load.md
+++ b/.claude/skills/sce-change-to-plan/references/context-load.md
@@ -61,7 +61,7 @@ sentence.
 
 ## 1.5 Return the brief
 
-Set exactly one internal state:
+Return one internal result with one of these statuses:
 
 - `loaded`
 - `bootstrap_required`
@@ -69,7 +69,7 @@ Set exactly one internal state:
 Report facts the workflow can act on. A brief that only lists file paths has
 moved no knowledge.
 
-Record only the internal state. Do not add explanatory prose before or after it.
+Return only the internal result. Do not add explanatory prose before or after it.
 
 Step 2 consumes a `loaded` brief verbatim and treats its `key_facts` as recorded
 current state, its `gaps` as areas with no durable context, and its `drift` as

--- a/.claude/skills/sce-change-to-plan/references/output.md
+++ b/.claude/skills/sce-change-to-plan/references/output.md
@@ -48,7 +48,7 @@ candidate plan paths and explain that naming one candidate resolves it.
 
 This plan is a draft. State a correction and it will be updated.
 
-Next up:
+Next step:
 
 {next-task-id} — {next-task-title}
 
@@ -71,17 +71,17 @@ This is chat output, not a file. Nothing here is written to the plan.
 
 Path: {plan.path}
 
-## Summary:
+## Summary
 {plan summary}
 
-## Tasks:
+## Tasks
 1. {task.id} — {task.title}
 2. {task.id} — {task.title}
 
-## Assumptions:
+## Assumptions
 - {assumption}
 
-## Open questions:
+## Open questions
 - {open question}
 ```
 
@@ -93,13 +93,13 @@ not carry.
 - `Plan:` — `plan.name`. Append ` (updated)` when `plan.action` is `updated`.
   Render nothing extra when it is `created`.
 - `Path:` — `plan.path`, exactly as returned, so it stays runnable.
-- `Summary:` — `summary`, as prose. This is the only place the reader learns
+- `Summary` — `summary`, as prose. This is the only place the reader learns
   what the plan actually does, so never omit it and never replace it with a
   restatement of the task titles.
-- `Tasks:` — one numbered line per entry in `tasks`, in plan order. Append
+- `Tasks` — one numbered line per entry in `tasks`, in plan order. Append
   ` (done)` to any task whose `status` is `done`.
-- `Assumptions:` — one line per entry in `assumptions`.
-- `Open questions:` — one line per entry in `open_questions`.
+- `Assumptions` — one line per entry in `assumptions`.
+- `Open questions` — one line per entry in `open_questions`.
 
 ## Empty sections
 
@@ -109,14 +109,14 @@ explicit `None.` confirms nothing is pending.
 When `assumptions` is empty:
 
 ```
-## Assumptions:
+## Assumptions
 - None.
 ```
 
 When `open_questions` is absent:
 
 ```
-## Open questions:
+## Open questions
 - None.
 ```
 
@@ -137,16 +137,16 @@ When `open_questions` is absent:
 
 Path: context/plans/red-sce-banner.md
 
-## Summary:
-Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Colour-disabled output is unchanged, and no other help surface is affected.
+## Summary
+Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Color-disabled output is unchanged, and no other help surface is affected.
 
-## Tasks:
+## Tasks
 1. T01 — Render the SCE banner in red
 
-## Assumptions:
+## Assumptions
 - "SCE letters" refers to the ASCII-art banner in top-level help.
 - Red is uniform terminal red when colors are enabled; plain ASCII remains unchanged otherwise.
 
-## Open questions:
+## Open questions
 - None.
 ```

--- a/.claude/skills/sce-change-to-plan/references/plan-authoring.md
+++ b/.claude/skills/sce-change-to-plan/references/plan-authoring.md
@@ -28,7 +28,7 @@ responsibility.
 
 The context brief is the durable memory this plan starts from. Treat its
 `key_facts` as recorded current state, its `gaps` as areas with no durable
-context, and its `drift` as context the code has already outrun.
+context, and its `drift` as recorded context that no longer matches the code.
 
 When no brief is supplied, load the context named by the change request before
 authoring, and follow the selection discipline in *Inspect relevant context*.
@@ -178,13 +178,13 @@ exactly. For revisions, apply its `Updating an existing plan` rules.
 
 ## 2.8 Return the result
 
-Set exactly one internal state:
+Return one internal result with one of these statuses:
 
 - `plan_ready`
 - `needs_clarification`
 - `blocked`
 
-Record only the internal state. Do not add explanatory prose before or after it.
+Return only the internal result. Do not add explanatory prose before or after it.
 
 A `plan_ready` result always names the next task in `next_task`, and carries the
 `total_tasks` count and any open questions the summary needs. Step 3 renders those
@@ -192,29 +192,13 @@ without recomputing them.
 
 ## Plan authoring tone
 
-Every question and open question this phase writes is read by the user. Write
-them the way a senior engineer talks in review: direct, specific, and unbothered
-by the possibility of being unwelcome.
+Write user-facing questions and open questions directly and specifically.
 
-- Ask about the thing that actually worries you, not a safer neighbouring thing.
-  A question you would not bother asking a colleague is not worth the user's
-  attention either.
-- State a doubt as a doubt. "I do not think this is worth the two tasks it
-  costs, because X" is useful. "It may be worth considering whether this aligns
-  with broader goals" is noise.
-- Name the alternative you have in mind. A challenge with no proposal behind it
-  is just friction.
-- Do not open with praise, do not close with reassurance, and do not apologize
-  for asking. Do not pad a doubt with hedges to make it land more gently.
-- Be persistent, not repetitive. Ask once, plainly, and let it stand; do not
-  restate the same doubt in three shapes to give it more weight.
-- Being disagreeable is not the goal. Being easy to agree with is the failure
-  mode. A plan the user waves through without reading has cost them nothing and
-  bought them nothing.
-
-When the user overrules a doubt, record it and move on. Do not relitigate a
-decision the user has made, and do not smuggle the objection back in as a
-constraint, a non-goal, or a task.
+- Ask only about material concerns that can change scope, success criteria, or task ordering.
+- State the concern and the concrete evidence for it.
+- Name a smaller or safer alternative when one is known.
+- Do not invent concerns, add praise or reassurance, or repeat the same concern in several forms.
+- When the user overrules a concern, record the decision and continue. Do not reintroduce it as a constraint, non-goal, or task.
 
 ## Plan authoring boundaries
 

--- a/.claude/skills/sce-change-to-plan/references/plan-template.md
+++ b/.claude/skills/sce-change-to-plan/references/plan-template.md
@@ -146,9 +146,9 @@ invent one: `None.` is the expected answer for a well-specified change.}
 
 - The last task in the stack is an ordinary implementation task. Do not author a
   trailing "validation and cleanup" task.
-- Final validation, cleanup, and success-criteria verification are run by
-  `/validate` from the `Acceptance criteria` section after the last task
-  completes.
+- Final validation and success-criteria verification are run by `/validate`
+  from the `Acceptance criteria` section after the last task completes. Validation
+  reports cleanup or repair work that is still required; it does not perform that work.
 - Do not author a task whose only purpose is running the full check suite,
   verifying durable context, or removing scaffolding.
 - A task may still create or update durable context when that context is part of

--- a/.claude/skills/sce-commit/SKILL.md
+++ b/.claude/skills/sce-commit/SKILL.md
@@ -11,10 +11,10 @@ compatibility: claude
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.
@@ -98,14 +98,14 @@ Run `git diff --cached --quiet`. A zero exit status means nothing is staged.
 When nothing is staged, stop with the **No staged changes** layout from
 `references/output.md`.
 
-Do not stage anything. Do not proceed to the skill.
+Do not stage anything. Do not proceed to the phase.
 
 #### 2. Request one commit message
 
 Read `references/atomic-commit.md`, then run the **Atomic commit phase** with
 `mode: bypass` and the commit context.
 
-Bypass mode is the skill's contract for producing exactly one message. Do not
+Bypass mode is the phase's contract for producing exactly one message. Do not
 restate its overrides here; the **Atomic commit phase** owns them.
 
 Branch on `status`:
@@ -114,7 +114,7 @@ Branch on `status`:
 
 `bypass_message` -> Continue to the next step.
 
-The skill never returns `proposal` in bypass mode. Treat a `proposal` result as
+The phase never returns `proposal` in bypass mode. Treat a `proposal` result as
 a contract violation: report it and stop without committing.
 
 #### 3. Execute exactly one commit

--- a/.claude/skills/sce-commit/references/atomic-commit.md
+++ b/.claude/skills/sce-commit/references/atomic-commit.md
@@ -1,4 +1,4 @@
-# SCE Atomic Commit
+# Atomic commit phase
 
 ## Purpose
 
@@ -8,8 +8,8 @@ Write messages matching:
 
 `references/commit-message-style.md`
 
-Committing is not this skill's job. The invoking `/commit` workflow decides
-whether a returned message is committed, and it is the only thing that runs
+This phase does not commit. The invoking `/commit` workflow decides
+whether a returned message is committed, and it is the only part that runs
 `git commit`.
 
 ## Input
@@ -147,7 +147,7 @@ Do not:
 
 ## Completion
 
-The skill is complete after:
+The phase is complete after:
 
 - The staged diff was read, or reading it failed and was reported.
 - Messages were written for every staged file, or a blocker prevented it.

--- a/.claude/skills/sce-handover/SKILL.md
+++ b/.claude/skills/sce-handover/SKILL.md
@@ -11,10 +11,10 @@ compatibility: claude
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.

--- a/.claude/skills/sce-handover/references/handover-template.md
+++ b/.claude/skills/sce-handover/references/handover-template.md
@@ -1,8 +1,10 @@
+# Handover document format
+
 The Markdown document writer mode creates under
 `context/handovers/{name}.md`. This is the persisted file's content, distinct
 from the terminal response defined in `references/output.md`.
 
-### Layout
+## Template
 
 ```markdown
 # Handover: {plan name or short session topic}
@@ -35,9 +37,9 @@ enough to act on directly.}
   `None.`}
 ```
 
-### Completeness contract
+## Completeness contract
 
-- The first four `##` sections shown in **Layout** are required and must appear
+- The first four `##` sections shown in **Template** are required and must appear
   in that order.
 - Each required section's content, up to the next `##` heading or the end of the
   file, must contain non-whitespace content. An empty list marker, unreplaced
@@ -47,10 +49,10 @@ enough to act on directly.}
 - Writer mode must satisfy this contract before reporting success; loader mode
   validates the same contract before presenting a handover.
 
-### Rules
+## Rules
 
-- Include `Plan` and `Task` only when the session was working one identifiable
-  plan task; omit them rather than guessing.
+- Include `Plan` when one plan is known. Include `Task` only when one task is
+  known. Omit either field rather than guessing its value.
 - Keep `Assumptions` scoped to details actually labeled as inferred elsewhere
   in the document; do not duplicate confirmed facts here.
 - Describe durable state useful to a future session, not a transcript of this

--- a/.claude/skills/sce-handover/references/output.md
+++ b/.claude/skills/sce-handover/references/output.md
@@ -83,7 +83,7 @@ This handover has been presented for continuation only. No file was edited, no
 plan task was marked complete, and the recommended next step was not started.
 ```
 
-# Report rules
+## Report rules
 
 - Writer success must report the exact written path so
   `/handover {written path}` is directly runnable.

--- a/.claude/skills/sce-next-task/SKILL.md
+++ b/.claude/skills/sce-next-task/SKILL.md
@@ -11,10 +11,10 @@ compatibility: claude
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command except `sce-decision`,
@@ -80,7 +80,7 @@ Branch on the outcome:
 
 `synced` | `no_context_change` -> Re-invoke the **Plan review phase** with the same `plan-name-or-path` and, when present, `task-id` to resume normal task selection.
 
-`plan_complete` -> Render the **Plan already complete** layout from `references/output.md`. Stop.
+`plan_complete` -> Render the **Implementation complete** layout from `references/output.md`. Stop.
 
 `ready` -> Pass the complete readiness result to the **Task execution phase**.
 
@@ -119,10 +119,9 @@ Branch on the execution result.
 ### 3. Synchronize context
 
 Read `references/context-sync.md`, then run the **Task context synchronization
-phase** with the complete `complete` result returned by the **Task execution
-phase**.
+phase** with the task execution result whose `status` is `complete`.
 
-Pass that `complete` result verbatim as the authoritative live handoff to the
+Pass that result unchanged as the authoritative live handoff to the
 **Task context synchronization phase**. Do not restate, summarize, or reconstruct it.
 
 This phase verifies the five root context files on every invocation, whatever the
@@ -139,7 +138,7 @@ Branch on the synchronization result.
 
 Do not select another task. Stop.
 
-`synced` | `no_context_change` -> Print out the report the **Task context synchronization phase** returned. Continue to the next step.
+`synced` | `no_context_change` -> Render the Markdown report returned by the **Task context synchronization phase** unchanged. Continue to the next step.
 
 ### 4. Determine the continuation
 

--- a/.claude/skills/sce-next-task/references/context-sync.md
+++ b/.claude/skills/sce-next-task/references/context-sync.md
@@ -7,7 +7,7 @@ plan state.
 
 Input: either the complete `complete` result from the task execution phase
 (same-session), passed verbatim, or the plan path and task ID a plan-review
-recovery step resolved for a `blocked` task, together with that task's own
+recovery step resolved for a completed task with unresolved context synchronization, together with that task's own
 completed record — read directly from the plan — and its persisted `Context
 synchronization blocker` when present (cross-session retry). Whichever was
 supplied is authoritative; this phase consumes it without redefining its shape.

--- a/.claude/skills/sce-next-task/references/output.md
+++ b/.claude/skills/sce-next-task/references/output.md
@@ -8,7 +8,7 @@ Present the selected task, then each issue's problem, impact, and required
 decision. If plan resolution is ambiguous, list candidate paths and
 `/next-task {candidate-path}`. State whether another task remains executable.
 
-## Plan already complete
+## Implementation complete
 
 ```markdown
 -------------------------------------

--- a/.claude/skills/sce-validate/SKILL.md
+++ b/.claude/skills/sce-validate/SKILL.md
@@ -11,10 +11,10 @@ compatibility: claude
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.
@@ -51,7 +51,7 @@ Pass the plan name or path to the **Validation phase** unmodified. Do not restat
 summarize, or pre-scope it.
 
 Every `{plan-path}` and `{candidate-path}` emitted anywhere in this workflow is
-the path carried by the **Validation phase** in its Markdown result (`Plan:`, or a
+the path carried by the **Validation phase** in its Markdown report (`Plan:`, or a
 candidate path), so every emitted command is directly runnable.
 
 ## Workflow

--- a/.claude/skills/sce-validate/references/validation.md
+++ b/.claude/skills/sce-validate/references/validation.md
@@ -1,4 +1,4 @@
-# SCE Validation
+# Validation phase
 
 ## Purpose
 
@@ -79,8 +79,7 @@ validation.
 
 When a check fails, record the failure and continue gathering evidence. Do not
 modify tests, application code, or configuration to make a check pass. Final
-validation measures the finished work; repair belongs to a later work session,
-not this skill.
+validation measures the finished work; repair belongs to a normal work session outside this phase.
 
 Never report a check as passed unless it ran successfully or the authorized
 inspection confirmed the criterion.
@@ -102,9 +101,9 @@ Do not reopen completed tasks, rewrite task evidence, or change the task stack.
 
 For `blocked`, leave the plan file unchanged.
 
-### 6. Return the Markdown result
+### 6. Return the Markdown report
 
-Return exactly one Markdown result:
+Return exactly one Markdown report:
 
 - `validated` when every acceptance criterion is met, required full validation
   passed, and the Validation Report was written.
@@ -141,12 +140,12 @@ The phase is complete after:
 - One plan was resolved, or resolution failed and was reported.
 - Implementation completeness was checked.
 - Validation ran to a terminal state, or a blocker prevented it.
-- One valid Markdown result matching the **Validation Result** section below in this file was
+- One valid Markdown report matching the **Validation Result** section below in this file was
   returned.
 
 
 
-# Validation Result
+# Validation report
 
 Return only one completed Markdown report using the applicable variant below.
 Do not include unused sections, placeholders, YAML, or a fenced code block.
@@ -158,10 +157,10 @@ The `Status` value must be exactly one of:
 - `blocked`
 
 The plan-file `## Validation Report` section is written separately using
-`references/validation-report.md`. This file is the skill's return value to the
+`references/validation-report.md`. This file is the phase's return value to the
 invoking workflow.
 
-## Validated variant
+## Validated report
 
 # Validation Report
 
@@ -192,7 +191,7 @@ Omit this section when unnecessary.}
 
 ---
 
-## Failed variant
+## Failed report
 
 This variant is a session handoff. Another agent or a later session must be
 able to act from it alone. Write it as a prompt the user can paste forward, not
@@ -256,7 +255,7 @@ returns `validated`.
 
 ---
 
-## Blocked variant
+## Blocked report
 
 # Validation blocked
 

--- a/.pi/skills/sce-change-to-plan/SKILL.md
+++ b/.pi/skills/sce-change-to-plan/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.

--- a/.pi/skills/sce-change-to-plan/references/context-load.md
+++ b/.pi/skills/sce-change-to-plan/references/context-load.md
@@ -61,7 +61,7 @@ sentence.
 
 ## 1.5 Return the brief
 
-Set exactly one internal state:
+Return one internal result with one of these statuses:
 
 - `loaded`
 - `bootstrap_required`
@@ -69,7 +69,7 @@ Set exactly one internal state:
 Report facts the workflow can act on. A brief that only lists file paths has
 moved no knowledge.
 
-Record only the internal state. Do not add explanatory prose before or after it.
+Return only the internal result. Do not add explanatory prose before or after it.
 
 Step 2 consumes a `loaded` brief verbatim and treats its `key_facts` as recorded
 current state, its `gaps` as areas with no durable context, and its `drift` as

--- a/.pi/skills/sce-change-to-plan/references/output.md
+++ b/.pi/skills/sce-change-to-plan/references/output.md
@@ -48,7 +48,7 @@ candidate plan paths and explain that naming one candidate resolves it.
 
 This plan is a draft. State a correction and it will be updated.
 
-Next up:
+Next step:
 
 {next-task-id} — {next-task-title}
 
@@ -71,17 +71,17 @@ This is chat output, not a file. Nothing here is written to the plan.
 
 Path: {plan.path}
 
-## Summary:
+## Summary
 {plan summary}
 
-## Tasks:
+## Tasks
 1. {task.id} — {task.title}
 2. {task.id} — {task.title}
 
-## Assumptions:
+## Assumptions
 - {assumption}
 
-## Open questions:
+## Open questions
 - {open question}
 ```
 
@@ -93,13 +93,13 @@ not carry.
 - `Plan:` — `plan.name`. Append ` (updated)` when `plan.action` is `updated`.
   Render nothing extra when it is `created`.
 - `Path:` — `plan.path`, exactly as returned, so it stays runnable.
-- `Summary:` — `summary`, as prose. This is the only place the reader learns
+- `Summary` — `summary`, as prose. This is the only place the reader learns
   what the plan actually does, so never omit it and never replace it with a
   restatement of the task titles.
-- `Tasks:` — one numbered line per entry in `tasks`, in plan order. Append
+- `Tasks` — one numbered line per entry in `tasks`, in plan order. Append
   ` (done)` to any task whose `status` is `done`.
-- `Assumptions:` — one line per entry in `assumptions`.
-- `Open questions:` — one line per entry in `open_questions`.
+- `Assumptions` — one line per entry in `assumptions`.
+- `Open questions` — one line per entry in `open_questions`.
 
 ## Empty sections
 
@@ -109,14 +109,14 @@ explicit `None.` confirms nothing is pending.
 When `assumptions` is empty:
 
 ```
-## Assumptions:
+## Assumptions
 - None.
 ```
 
 When `open_questions` is absent:
 
 ```
-## Open questions:
+## Open questions
 - None.
 ```
 
@@ -137,16 +137,16 @@ When `open_questions` is absent:
 
 Path: context/plans/red-sce-banner.md
 
-## Summary:
-Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Colour-disabled output is unchanged, and no other help surface is affected.
+## Summary
+Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Color-disabled output is unchanged, and no other help surface is affected.
 
-## Tasks:
+## Tasks
 1. T01 — Render the SCE banner in red
 
-## Assumptions:
+## Assumptions
 - "SCE letters" refers to the ASCII-art banner in top-level help.
 - Red is uniform terminal red when colors are enabled; plain ASCII remains unchanged otherwise.
 
-## Open questions:
+## Open questions
 - None.
 ```

--- a/.pi/skills/sce-change-to-plan/references/plan-authoring.md
+++ b/.pi/skills/sce-change-to-plan/references/plan-authoring.md
@@ -28,7 +28,7 @@ responsibility.
 
 The context brief is the durable memory this plan starts from. Treat its
 `key_facts` as recorded current state, its `gaps` as areas with no durable
-context, and its `drift` as context the code has already outrun.
+context, and its `drift` as recorded context that no longer matches the code.
 
 When no brief is supplied, load the context named by the change request before
 authoring, and follow the selection discipline in *Inspect relevant context*.
@@ -178,13 +178,13 @@ exactly. For revisions, apply its `Updating an existing plan` rules.
 
 ## 2.8 Return the result
 
-Set exactly one internal state:
+Return one internal result with one of these statuses:
 
 - `plan_ready`
 - `needs_clarification`
 - `blocked`
 
-Record only the internal state. Do not add explanatory prose before or after it.
+Return only the internal result. Do not add explanatory prose before or after it.
 
 A `plan_ready` result always names the next task in `next_task`, and carries the
 `total_tasks` count and any open questions the summary needs. Step 3 renders those
@@ -192,29 +192,13 @@ without recomputing them.
 
 ## Plan authoring tone
 
-Every question and open question this phase writes is read by the user. Write
-them the way a senior engineer talks in review: direct, specific, and unbothered
-by the possibility of being unwelcome.
+Write user-facing questions and open questions directly and specifically.
 
-- Ask about the thing that actually worries you, not a safer neighbouring thing.
-  A question you would not bother asking a colleague is not worth the user's
-  attention either.
-- State a doubt as a doubt. "I do not think this is worth the two tasks it
-  costs, because X" is useful. "It may be worth considering whether this aligns
-  with broader goals" is noise.
-- Name the alternative you have in mind. A challenge with no proposal behind it
-  is just friction.
-- Do not open with praise, do not close with reassurance, and do not apologize
-  for asking. Do not pad a doubt with hedges to make it land more gently.
-- Be persistent, not repetitive. Ask once, plainly, and let it stand; do not
-  restate the same doubt in three shapes to give it more weight.
-- Being disagreeable is not the goal. Being easy to agree with is the failure
-  mode. A plan the user waves through without reading has cost them nothing and
-  bought them nothing.
-
-When the user overrules a doubt, record it and move on. Do not relitigate a
-decision the user has made, and do not smuggle the objection back in as a
-constraint, a non-goal, or a task.
+- Ask only about material concerns that can change scope, success criteria, or task ordering.
+- State the concern and the concrete evidence for it.
+- Name a smaller or safer alternative when one is known.
+- Do not invent concerns, add praise or reassurance, or repeat the same concern in several forms.
+- When the user overrules a concern, record the decision and continue. Do not reintroduce it as a constraint, non-goal, or task.
 
 ## Plan authoring boundaries
 

--- a/.pi/skills/sce-change-to-plan/references/plan-template.md
+++ b/.pi/skills/sce-change-to-plan/references/plan-template.md
@@ -146,9 +146,9 @@ invent one: `None.` is the expected answer for a well-specified change.}
 
 - The last task in the stack is an ordinary implementation task. Do not author a
   trailing "validation and cleanup" task.
-- Final validation, cleanup, and success-criteria verification are run by
-  `/validate` from the `Acceptance criteria` section after the last task
-  completes.
+- Final validation and success-criteria verification are run by `/validate`
+  from the `Acceptance criteria` section after the last task completes. Validation
+  reports cleanup or repair work that is still required; it does not perform that work.
 - Do not author a task whose only purpose is running the full check suite,
   verifying durable context, or removing scaffolding.
 - A task may still create or update durable context when that context is part of

--- a/.pi/skills/sce-commit/SKILL.md
+++ b/.pi/skills/sce-commit/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.
@@ -97,14 +97,14 @@ Run `git diff --cached --quiet`. A zero exit status means nothing is staged.
 When nothing is staged, stop with the **No staged changes** layout from
 `references/output.md`.
 
-Do not stage anything. Do not proceed to the skill.
+Do not stage anything. Do not proceed to the phase.
 
 #### 2. Request one commit message
 
 Read `references/atomic-commit.md`, then run the **Atomic commit phase** with
 `mode: bypass` and the commit context.
 
-Bypass mode is the skill's contract for producing exactly one message. Do not
+Bypass mode is the phase's contract for producing exactly one message. Do not
 restate its overrides here; the **Atomic commit phase** owns them.
 
 Branch on `status`:
@@ -113,7 +113,7 @@ Branch on `status`:
 
 `bypass_message` -> Continue to the next step.
 
-The skill never returns `proposal` in bypass mode. Treat a `proposal` result as
+The phase never returns `proposal` in bypass mode. Treat a `proposal` result as
 a contract violation: report it and stop without committing.
 
 #### 3. Execute exactly one commit

--- a/.pi/skills/sce-commit/references/atomic-commit.md
+++ b/.pi/skills/sce-commit/references/atomic-commit.md
@@ -1,4 +1,4 @@
-# SCE Atomic Commit
+# Atomic commit phase
 
 ## Purpose
 
@@ -8,8 +8,8 @@ Write messages matching:
 
 `references/commit-message-style.md`
 
-Committing is not this skill's job. The invoking `/commit` workflow decides
-whether a returned message is committed, and it is the only thing that runs
+This phase does not commit. The invoking `/commit` workflow decides
+whether a returned message is committed, and it is the only part that runs
 `git commit`.
 
 ## Input
@@ -147,7 +147,7 @@ Do not:
 
 ## Completion
 
-The skill is complete after:
+The phase is complete after:
 
 - The staged diff was read, or reading it failed and was reported.
 - Messages were written for every staged file, or a blocker prevented it.

--- a/.pi/skills/sce-handover/SKILL.md
+++ b/.pi/skills/sce-handover/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.

--- a/.pi/skills/sce-handover/references/handover-template.md
+++ b/.pi/skills/sce-handover/references/handover-template.md
@@ -1,8 +1,10 @@
+# Handover document format
+
 The Markdown document writer mode creates under
 `context/handovers/{name}.md`. This is the persisted file's content, distinct
 from the terminal response defined in `references/output.md`.
 
-### Layout
+## Template
 
 ```markdown
 # Handover: {plan name or short session topic}
@@ -35,9 +37,9 @@ enough to act on directly.}
   `None.`}
 ```
 
-### Completeness contract
+## Completeness contract
 
-- The first four `##` sections shown in **Layout** are required and must appear
+- The first four `##` sections shown in **Template** are required and must appear
   in that order.
 - Each required section's content, up to the next `##` heading or the end of the
   file, must contain non-whitespace content. An empty list marker, unreplaced
@@ -47,10 +49,10 @@ enough to act on directly.}
 - Writer mode must satisfy this contract before reporting success; loader mode
   validates the same contract before presenting a handover.
 
-### Rules
+## Rules
 
-- Include `Plan` and `Task` only when the session was working one identifiable
-  plan task; omit them rather than guessing.
+- Include `Plan` when one plan is known. Include `Task` only when one task is
+  known. Omit either field rather than guessing its value.
 - Keep `Assumptions` scoped to details actually labeled as inferred elsewhere
   in the document; do not duplicate confirmed facts here.
 - Describe durable state useful to a future session, not a transcript of this

--- a/.pi/skills/sce-handover/references/output.md
+++ b/.pi/skills/sce-handover/references/output.md
@@ -83,7 +83,7 @@ This handover has been presented for continuation only. No file was edited, no
 plan task was marked complete, and the recommended next step was not started.
 ```
 
-# Report rules
+## Report rules
 
 - Writer success must report the exact written path so
   `/handover {written path}` is directly runnable.

--- a/.pi/skills/sce-next-task/SKILL.md
+++ b/.pi/skills/sce-next-task/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command except `sce-decision`,
@@ -79,7 +79,7 @@ Branch on the outcome:
 
 `synced` | `no_context_change` -> Re-invoke the **Plan review phase** with the same `plan-name-or-path` and, when present, `task-id` to resume normal task selection.
 
-`plan_complete` -> Render the **Plan already complete** layout from `references/output.md`. Stop.
+`plan_complete` -> Render the **Implementation complete** layout from `references/output.md`. Stop.
 
 `ready` -> Pass the complete readiness result to the **Task execution phase**.
 
@@ -118,10 +118,9 @@ Branch on the execution result.
 ### 3. Synchronize context
 
 Read `references/context-sync.md`, then run the **Task context synchronization
-phase** with the complete `complete` result returned by the **Task execution
-phase**.
+phase** with the task execution result whose `status` is `complete`.
 
-Pass that `complete` result verbatim as the authoritative live handoff to the
+Pass that result unchanged as the authoritative live handoff to the
 **Task context synchronization phase**. Do not restate, summarize, or reconstruct it.
 
 This phase verifies the five root context files on every invocation, whatever the
@@ -138,7 +137,7 @@ Branch on the synchronization result.
 
 Do not select another task. Stop.
 
-`synced` | `no_context_change` -> Print out the report the **Task context synchronization phase** returned. Continue to the next step.
+`synced` | `no_context_change` -> Render the Markdown report returned by the **Task context synchronization phase** unchanged. Continue to the next step.
 
 ### 4. Determine the continuation
 

--- a/.pi/skills/sce-next-task/references/context-sync.md
+++ b/.pi/skills/sce-next-task/references/context-sync.md
@@ -7,7 +7,7 @@ plan state.
 
 Input: either the complete `complete` result from the task execution phase
 (same-session), passed verbatim, or the plan path and task ID a plan-review
-recovery step resolved for a `blocked` task, together with that task's own
+recovery step resolved for a completed task with unresolved context synchronization, together with that task's own
 completed record — read directly from the plan — and its persisted `Context
 synchronization blocker` when present (cross-session retry). Whichever was
 supplied is authoritative; this phase consumes it without redefining its shape.

--- a/.pi/skills/sce-next-task/references/output.md
+++ b/.pi/skills/sce-next-task/references/output.md
@@ -8,7 +8,7 @@ Present the selected task, then each issue's problem, impact, and required
 decision. If plan resolution is ambiguous, list candidate paths and
 `/next-task {candidate-path}`. State whether another task remains executable.
 
-## Plan already complete
+## Implementation complete
 
 ```markdown
 -------------------------------------

--- a/.pi/skills/sce-validate/SKILL.md
+++ b/.pi/skills/sce-validate/SKILL.md
@@ -10,10 +10,10 @@ description: >
 
 Own this workflow from input through its terminal user-visible response.
 Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-Keep phase results internal and continue immediately until a defined wait or stop.
+Keep internal phase results private and continue immediately until a defined wait or stop.
 Resume user waits in this same skill and session.
-Use only the specified `references/output.md` layouts for gates and terminal
-responses. Do not expose raw state or add text around a layout.
+Render user-visible output only from the named workflow layouts or phase reports.
+Do not expose raw internal state or add text around a rendered layout or report.
 Non-SCE helpers may assist, but must return to the active step without changing
 phase order, gates, waits, writes, validation, stops, or terminal output.
 Do not invoke another SCE skill, package, or workflow command.
@@ -50,7 +50,7 @@ Pass the plan name or path to the **Validation phase** unmodified. Do not restat
 summarize, or pre-scope it.
 
 Every `{plan-path}` and `{candidate-path}` emitted anywhere in this workflow is
-the path carried by the **Validation phase** in its Markdown result (`Plan:`, or a
+the path carried by the **Validation phase** in its Markdown report (`Plan:`, or a
 candidate path), so every emitted command is directly runnable.
 
 ## Workflow

--- a/.pi/skills/sce-validate/references/validation.md
+++ b/.pi/skills/sce-validate/references/validation.md
@@ -1,4 +1,4 @@
-# SCE Validation
+# Validation phase
 
 ## Purpose
 
@@ -79,8 +79,7 @@ validation.
 
 When a check fails, record the failure and continue gathering evidence. Do not
 modify tests, application code, or configuration to make a check pass. Final
-validation measures the finished work; repair belongs to a later work session,
-not this skill.
+validation measures the finished work; repair belongs to a normal work session outside this phase.
 
 Never report a check as passed unless it ran successfully or the authorized
 inspection confirmed the criterion.
@@ -102,9 +101,9 @@ Do not reopen completed tasks, rewrite task evidence, or change the task stack.
 
 For `blocked`, leave the plan file unchanged.
 
-### 6. Return the Markdown result
+### 6. Return the Markdown report
 
-Return exactly one Markdown result:
+Return exactly one Markdown report:
 
 - `validated` when every acceptance criterion is met, required full validation
   passed, and the Validation Report was written.
@@ -141,12 +140,12 @@ The phase is complete after:
 - One plan was resolved, or resolution failed and was reported.
 - Implementation completeness was checked.
 - Validation ran to a terminal state, or a blocker prevented it.
-- One valid Markdown result matching the **Validation Result** section below in this file was
+- One valid Markdown report matching the **Validation Result** section below in this file was
   returned.
 
 
 
-# Validation Result
+# Validation report
 
 Return only one completed Markdown report using the applicable variant below.
 Do not include unused sections, placeholders, YAML, or a fenced code block.
@@ -158,10 +157,10 @@ The `Status` value must be exactly one of:
 - `blocked`
 
 The plan-file `## Validation Report` section is written separately using
-`references/validation-report.md`. This file is the skill's return value to the
+`references/validation-report.md`. This file is the phase's return value to the
 invoking workflow.
 
-## Validated variant
+## Validated report
 
 # Validation Report
 
@@ -192,7 +191,7 @@ Omit this section when unnecessary.}
 
 ---
 
-## Failed variant
+## Failed report
 
 This variant is a session handoff. Another agent or a later session must be
 able to act from it alone. Write it as a prompt the user can paste forward, not
@@ -256,7 +255,7 @@ returns `validated`.
 
 ---
 
-## Blocked variant
+## Blocked report
 
 # Validation blocked
 

--- a/config/pkl/base/workflow-change-to-plan.pkl
+++ b/config/pkl/base/workflow-change-to-plan.pkl
@@ -210,7 +210,7 @@ sentence.
 
 ## 1.5 Return the brief
 
-Set exactly one internal state:
+Return one internal result with one of these statuses:
 
 - `loaded`
 - `bootstrap_required`
@@ -218,7 +218,7 @@ Set exactly one internal state:
 Report facts the workflow can act on. A brief that only lists file paths has
 moved no knowledge.
 
-Record only the internal state. Do not add explanatory prose before or after it.
+Return only the internal result. Do not add explanatory prose before or after it.
 
 Step 2 consumes a `loaded` brief verbatim and treats its `key_facts` as recorded
 current state, its `gaps` as areas with no durable context, and its `drift` as
@@ -271,7 +271,7 @@ responsibility.
 
 The context brief is the durable memory this plan starts from. Treat its
 `key_facts` as recorded current state, its `gaps` as areas with no durable
-context, and its `drift` as context the code has already outrun.
+context, and its `drift` as recorded context that no longer matches the code.
 
 When no brief is supplied, load the context named by the change request before
 authoring, and follow the selection discipline in *Inspect relevant context*.
@@ -421,13 +421,13 @@ exactly. For revisions, apply its `Updating an existing plan` rules.
 
 ## 2.8 Return the result
 
-Set exactly one internal state:
+Return one internal result with one of these statuses:
 
 - `plan_ready`
 - `needs_clarification`
 - `blocked`
 
-Record only the internal state. Do not add explanatory prose before or after it.
+Return only the internal result. Do not add explanatory prose before or after it.
 
 A `plan_ready` result always names the next task in `next_task`, and carries the
 `total_tasks` count and any open questions the summary needs. Step 3 renders those
@@ -435,29 +435,13 @@ without recomputing them.
 
 ## Plan authoring tone
 
-Every question and open question this phase writes is read by the user. Write
-them the way a senior engineer talks in review: direct, specific, and unbothered
-by the possibility of being unwelcome.
+Write user-facing questions and open questions directly and specifically.
 
-- Ask about the thing that actually worries you, not a safer neighbouring thing.
-  A question you would not bother asking a colleague is not worth the user's
-  attention either.
-- State a doubt as a doubt. "I do not think this is worth the two tasks it
-  costs, because X" is useful. "It may be worth considering whether this aligns
-  with broader goals" is noise.
-- Name the alternative you have in mind. A challenge with no proposal behind it
-  is just friction.
-- Do not open with praise, do not close with reassurance, and do not apologize
-  for asking. Do not pad a doubt with hedges to make it land more gently.
-- Be persistent, not repetitive. Ask once, plainly, and let it stand; do not
-  restate the same doubt in three shapes to give it more weight.
-- Being disagreeable is not the goal. Being easy to agree with is the failure
-  mode. A plan the user waves through without reading has cost them nothing and
-  bought them nothing.
-
-When the user overrules a doubt, record it and move on. Do not relitigate a
-decision the user has made, and do not smuggle the objection back in as a
-constraint, a non-goal, or a task.
+- Ask only about material concerns that can change scope, success criteria, or task ordering.
+- State the concern and the concrete evidence for it.
+- Name a smaller or safer alternative when one is known.
+- Do not invent concerns, add praise or reassurance, or repeat the same concern in several forms.
+- When the user overrules a concern, record the decision and continue. Do not reintroduce it as a constraint, non-goal, or task.
 
 ## Plan authoring boundaries
 
@@ -633,9 +617,9 @@ invent one: `None.` is the expected answer for a well-specified change.}
 
 - The last task in the stack is an ordinary implementation task. Do not author a
   trailing "validation and cleanup" task.
-- Final validation, cleanup, and success-criteria verification are run by
-  `/validate` from the `Acceptance criteria` section after the last task
-  completes.
+- Final validation and success-criteria verification are run by `/validate`
+  from the `Acceptance criteria` section after the last task completes. Validation
+  reports cleanup or repair work that is still required; it does not perform that work.
 - Do not author a task whose only purpose is running the full check suite,
   verifying durable context, or removing scaffolding.
 - A task may still create or update durable context when that context is part of
@@ -725,7 +709,7 @@ candidate plan paths and explain that naming one candidate resolves it.
 
 This plan is a draft. State a correction and it will be updated.
 
-Next up:
+Next step:
 
 {next-task-id} — {next-task-title}
 
@@ -748,17 +732,17 @@ This is chat output, not a file. Nothing here is written to the plan.
 
 Path: {plan.path}
 
-## Summary:
+## Summary
 {plan summary}
 
-## Tasks:
+## Tasks
 1. {task.id} — {task.title}
 2. {task.id} — {task.title}
 
-## Assumptions:
+## Assumptions
 - {assumption}
 
-## Open questions:
+## Open questions
 - {open question}
 ```
 
@@ -770,13 +754,13 @@ not carry.
 - `Plan:` — `plan.name`. Append ` (updated)` when `plan.action` is `updated`.
   Render nothing extra when it is `created`.
 - `Path:` — `plan.path`, exactly as returned, so it stays runnable.
-- `Summary:` — `summary`, as prose. This is the only place the reader learns
+- `Summary` — `summary`, as prose. This is the only place the reader learns
   what the plan actually does, so never omit it and never replace it with a
   restatement of the task titles.
-- `Tasks:` — one numbered line per entry in `tasks`, in plan order. Append
+- `Tasks` — one numbered line per entry in `tasks`, in plan order. Append
   ` (done)` to any task whose `status` is `done`.
-- `Assumptions:` — one line per entry in `assumptions`.
-- `Open questions:` — one line per entry in `open_questions`.
+- `Assumptions` — one line per entry in `assumptions`.
+- `Open questions` — one line per entry in `open_questions`.
 
 ## Empty sections
 
@@ -786,14 +770,14 @@ explicit `None.` confirms nothing is pending.
 When `assumptions` is empty:
 
 ```
-## Assumptions:
+## Assumptions
 - None.
 ```
 
 When `open_questions` is absent:
 
 ```
-## Open questions:
+## Open questions
 - None.
 ```
 
@@ -814,17 +798,17 @@ When `open_questions` is absent:
 
 Path: context/plans/red-sce-banner.md
 
-## Summary:
-Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Colour-disabled output is unchanged, and no other help surface is affected.
+## Summary
+Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Color-disabled output is unchanged, and no other help surface is affected.
 
-## Tasks:
+## Tasks
 1. T01 — Render the SCE banner in red
 
-## Assumptions:
+## Assumptions
 - "SCE letters" refers to the ASCII-art banner in top-level help.
 - Red is uniform terminal red when colors are enabled; plain ASCII remains unchanged otherwise.
 
-## Open questions:
+## Open questions
 - None.
 ```
 """
@@ -975,7 +959,7 @@ local readyContinuationLayout = model.semanticReference.apply(
 
   This plan is a draft. State a correction and it will be updated.
 
-  Next up:
+  Next step:
 
   {next-task-id} — {next-task-title}
 
@@ -1486,7 +1470,7 @@ local renderAuthoringSkillBody = (mode: model.WorkflowRenderMode) -> """
 
     The context brief is the durable memory this plan starts from. Treat its
     `key_facts` as recorded current state, its `gaps` as areas with no durable
-    context, and its `drift` as context the code has already outrun.
+    context, and its `drift` as recorded context that no longer matches the code.
 
     When no brief is supplied, load the context named by the change request before
     authoring, and follow the selection discipline in *Inspect relevant context*.
@@ -2205,17 +2189,17 @@ local PLAN_SUMMARY = """
 
     Path: {plan.path}
 
-    ## Summary:
+    ## Summary
     {plan summary}
 
-    ## Tasks:
+    ## Tasks
     1. {task.id} — {task.title}
     2. {task.id} — {task.title}
 
-    ## Assumptions:
+    ## Assumptions
     - {assumption}
 
-    ## Open questions:
+    ## Open questions
     - {open question}
     ```
 
@@ -2227,13 +2211,13 @@ local PLAN_SUMMARY = """
     - `Plan:` — `plan.name`. Append ` (updated)` when `plan.action` is `updated`.
       Render nothing extra when it is `created`.
     - `Path:` — `plan.path`, exactly as returned, so it stays runnable.
-    - `Summary:` — `summary`, as prose. This is the only place the reader learns
+    - `Summary` — `summary`, as prose. This is the only place the reader learns
       what the plan actually does, so never omit it and never replace it with a
       restatement of the task titles.
-    - `Tasks:` — one numbered line per entry in `tasks`, in plan order. Append
+    - `Tasks` — one numbered line per entry in `tasks`, in plan order. Append
       ` (done)` to any task whose `status` is `done`.
-    - `Assumptions:` — one line per entry in `assumptions`.
-    - `Open questions:` — one line per entry in `open_questions`.
+    - `Assumptions` — one line per entry in `assumptions`.
+    - `Open questions` — one line per entry in `open_questions`.
 
     ## Empty sections
 
@@ -2243,14 +2227,14 @@ local PLAN_SUMMARY = """
     When `assumptions` is empty:
 
     ```
-    ## Assumptions:
+    ## Assumptions
     - None.
     ```
 
     When `open_questions` is absent:
 
     ```
-    ## Open questions:
+    ## Open questions
     - None.
     ```
 
@@ -2271,17 +2255,17 @@ local PLAN_SUMMARY = """
 
     Path: context/plans/red-sce-banner.md
 
-    ## Summary:
-    Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Colour-disabled output is unchanged, and no other help surface is affected.
+    ## Summary
+    Renders the ASCII-art SCE banner at the top of `sce` help in red instead of the current gradient. Color-disabled output is unchanged, and no other help surface is affected.
 
-    ## Tasks:
+    ## Tasks
     1. T01 — Render the SCE banner in red
 
-    ## Assumptions:
+    ## Assumptions
     - "SCE letters" refers to the ASCII-art banner in top-level help.
     - Red is uniform terminal red when colors are enabled; plain ASCII remains unchanged otherwise.
 
-    ## Open questions:
+    ## Open questions
     - None.
     ```
     """

--- a/config/pkl/base/workflow-commit.pkl
+++ b/config/pkl/base/workflow-commit.pkl
@@ -182,13 +182,13 @@ local renderCommandBody = (mode: model.WorkflowRenderMode) -> """
 
     \(noStagedChangesLayout.render.apply(mode))
 
-    Do not stage anything. Do not proceed to the skill.
+    Do not stage anything. Do not proceed to the phase.
 
     #### 2. Request one commit message
 
     \(invoke.render.apply(mode)) \(atomicCommit.render.apply(mode))\(bypassPhaseReferenceQualifier.render.apply(mode)) with `mode: bypass` and the commit context.
 
-    Bypass mode is the skill's contract for producing exactly one message. Do not
+    Bypass mode is the phase's contract for producing exactly one message. Do not
     restate its overrides here; \(atomicCommit.render.apply(mode)) owns them.
 
     \(commitContractHandoff.render.apply(mode))
@@ -197,7 +197,7 @@ local renderCommandBody = (mode: model.WorkflowRenderMode) -> """
 
     `bypass_message` -> Continue to the next step.
 
-    The skill never returns `proposal` in bypass mode. Treat a `proposal` result as
+    The phase never returns `proposal` in bypass mode. Treat a `proposal` result as
     a contract violation: report it and stop without committing.
 
     #### 3. Execute exactly one commit
@@ -245,7 +245,7 @@ local COMMAND = structuredCommand.render.apply("package", "").text
 
 local renderAtomicCommitSkillBody = (mode: model.WorkflowRenderMode) -> """
     \(model.packageOnlyBlock.apply("""
-    # SCE Atomic Commit
+    # Atomic commit phase
 
     ## Purpose
 
@@ -255,8 +255,8 @@ local renderAtomicCommitSkillBody = (mode: model.WorkflowRenderMode) -> """
 
     \(commitMessageStyle.render.apply(mode))
 
-    Committing is not this skill's job. The invoking `/commit` workflow decides
-    whether a returned message is committed, and it is the only thing that runs
+    This phase does not commit. The invoking `/commit` workflow decides
+    whether a returned message is committed, and it is the only part that runs
     `git commit`.
 
     ## Input
@@ -392,7 +392,7 @@ local renderAtomicCommitSkillBody = (mode: model.WorkflowRenderMode) -> """
 
     ## Completion
 
-    The skill is complete after:
+    The phase is complete after:
 
     - The staged diff was read, or reading it failed and was reported.
     - Messages were written for every staged file, or a blocker prevented it.
@@ -552,14 +552,14 @@ Run `git diff --cached --quiet`. A zero exit status means nothing is staged.
 When nothing is staged, stop with the **No staged changes** layout from
 `references/output.md`.
 
-Do not stage anything. Do not proceed to the skill.
+Do not stage anything. Do not proceed to the phase.
 
 #### 2. Request one commit message
 
 Read `references/atomic-commit.md`, then run the **Atomic commit phase** with
 `mode: bypass` and the commit context.
 
-Bypass mode is the skill's contract for producing exactly one message. Do not
+Bypass mode is the phase's contract for producing exactly one message. Do not
 restate its overrides here; the **Atomic commit phase** owns them.
 
 Branch on `status`:
@@ -568,7 +568,7 @@ Branch on `status`:
 
 `bypass_message` -> Continue to the next step.
 
-The skill never returns `proposal` in bypass mode. Treat a `proposal` result as
+The phase never returns `proposal` in bypass mode. Treat a `proposal` result as
 a contract violation: report it and stop without committing.
 
 #### 3. Execute exactly one commit

--- a/config/pkl/base/workflow-content.pkl
+++ b/config/pkl/base/workflow-content.pkl
@@ -217,10 +217,10 @@ hidden executionContract = (variant: ExecutionContractVariant) ->
 
   Own this workflow from input through its terminal user-visible response.
   Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-  Keep phase results internal and continue immediately until a defined wait or stop.
+  Keep internal phase results private and continue immediately until a defined wait or stop.
   Resume user waits in this same skill and session.
-  Use only the specified `references/output.md` layouts for gates and terminal
-  responses. Do not expose raw state or add text around a layout.
+  Render user-visible output only from the named workflow layouts or phase reports.
+  Do not expose raw internal state or add text around a rendered layout or report.
   Non-SCE helpers may assist, but must return to the active step without changing
   phase order, gates, waits, writes, validation, stops, or terminal output.
   """ + "\n" + if (variant == "task-decision")
@@ -296,7 +296,7 @@ Branch on the outcome:
 
 `synced` | `no_context_change` -> Re-invoke the **Plan review phase** with the same `plan-name-or-path` and, when present, `task-id` to resume normal task selection.
 
-`plan_complete` -> Render the **Plan already complete** layout from `references/output.md`. Stop.
+`plan_complete` -> Render the **Implementation complete** layout from `references/output.md`. Stop.
 
 `ready` -> Pass the complete readiness result to the **Task execution phase**.
 
@@ -335,10 +335,9 @@ Branch on the execution result.
 ### 3. Synchronize context
 
 Read `references/context-sync.md`, then run the **Task context synchronization
-phase** with the complete `complete` result returned by the **Task execution
-phase**.
+phase** with the task execution result whose `status` is `complete`.
 
-Pass that `complete` result verbatim as the authoritative live handoff to the
+Pass that result unchanged as the authoritative live handoff to the
 **Task context synchronization phase**. Do not restate, summarize, or reconstruct it.
 
 This phase verifies the five root context files on every invocation, whatever the
@@ -355,7 +354,7 @@ Branch on the synchronization result.
 
 Do not select another task. Stop.
 
-`synced` | `no_context_change` -> Print out the report the **Task context synchronization phase** returned. Continue to the next step.
+`synced` | `no_context_change` -> Render the Markdown report returned by the **Task context synchronization phase** unchanged. Continue to the next step.
 
 ### 4. Determine the continuation
 
@@ -424,7 +423,7 @@ Pass the plan name or path to the **Validation phase** unmodified. Do not restat
 summarize, or pre-scope it.
 
 Every `{plan-path}` and `{candidate-path}` emitted anywhere in this workflow is
-the path carried by the **Validation phase** in its Markdown result (`Plan:`, or a
+the path carried by the **Validation phase** in its Markdown report (`Plan:`, or a
 candidate path), so every emitted command is directly runnable.
 
 \(invocationExampleParagraph.apply(invocationExample))## Workflow

--- a/config/pkl/base/workflow-context-sync.pkl
+++ b/config/pkl/base/workflow-context-sync.pkl
@@ -66,7 +66,7 @@ local skillText = (role: SyncRole, mode: workflow.WorkflowRenderMode) ->
 
 local decisionGate = (evidenceSource: String, mode: workflow.WorkflowRenderMode) -> """
     This subsection is the sole owner of decision qualification. The threshold below
-    decides whether `sce-decision` is invoked; the decision skill consumes that gate
+    decides whether `sce-decision` is invoked; the decision skill consumes that qualification
     result and must not restate or broaden it.
 
     During this successful synchronization, determine whether the completed change
@@ -156,7 +156,7 @@ local taskRoleData = new SyncRole {
 
     Either the complete result returned by the task-execution phase
     (same-session), or the plan path and task ID a plan-review recovery step
-    resolved for a `blocked` task, together with that task's own completed
+    resolved for a completed task with unresolved context synchronization, together with that task's own completed
     record — read directly from the plan — and its persisted `Context
     synchronization blocker` when present (cross-session retry).
     """).render.apply(mode))A live execution result must have:
@@ -1129,7 +1129,7 @@ plan state.
 
 Input: either the complete `complete` result from the task execution phase
 (same-session), passed verbatim, or the plan path and task ID a plan-review
-recovery step resolved for a `blocked` task, together with that task's own
+recovery step resolved for a completed task with unresolved context synchronization, together with that task's own
 completed record — read directly from the plan — and its persisted `Context
 synchronization blocker` when present (cross-session retry). Whichever was
 supplied is authoritative; this phase consumes it without redefining its shape.

--- a/config/pkl/base/workflow-handover.pkl
+++ b/config/pkl/base/workflow-handover.pkl
@@ -43,11 +43,13 @@ local titleAndPurpose = model.packageOnlyBlock.apply("""
     """)
 
 local renderPersistedFormatBody = """
+    # Handover document format
+
     The Markdown document writer mode creates under
     `context/handovers/{name}.md`. This is the persisted file's content, distinct
     from the terminal response defined in `references/output.md`.
 
-    ### Layout
+    ## Template
 
     ```markdown
     # Handover: {plan name or short session topic}
@@ -80,9 +82,9 @@ local renderPersistedFormatBody = """
       `None.`}
     ```
 
-    ### Completeness contract
+    ## Completeness contract
 
-    - The first four `##` sections shown in **Layout** are required and must appear
+    - The first four `##` sections shown in **Template** are required and must appear
       in that order.
     - Each required section's content, up to the next `##` heading or the end of the
       file, must contain non-whitespace content. An empty list marker, unreplaced
@@ -92,10 +94,10 @@ local renderPersistedFormatBody = """
     - Writer mode must satisfy this contract before reporting success; loader mode
       validates the same contract before presenting a handover.
 
-    ### Rules
+    ## Rules
 
-    - Include `Plan` and `Task` only when the session was working one identifiable
-      plan task; omit them rather than guessing.
+    - Include `Plan` when one plan is known. Include `Task` only when one task is
+      known. Omit either field rather than guessing its value.
     - Keep `Assumptions` scoped to details actually labeled as inferred elsewhere
       in the document; do not duplicate confirmed facts here.
     - Describe durable state useful to a future session, not a transcript of this
@@ -330,7 +332,7 @@ local OUTPUT_MD = (argumentsReference: String) -> """
     plan task was marked complete, and the recommended next step was not started.
     ```
 
-    # Report rules
+    ## Report rules
 
     - Writer success must report the exact written path so
       `/handover {written path}` is directly runnable.

--- a/config/pkl/base/workflow-next-task.pkl
+++ b/config/pkl/base/workflow-next-task.pkl
@@ -1848,7 +1848,7 @@ Present the selected task, then each issue's problem, impact, and required
 decision. If plan resolution is ambiguous, list candidate paths and
 `/next-task {candidate-path}`. State whether another task remains executable.
 
-## Plan already complete
+## Implementation complete
 
 ```markdown
 -------------------------------------

--- a/config/pkl/base/workflow-validate.pkl
+++ b/config/pkl/base/workflow-validate.pkl
@@ -18,7 +18,7 @@ local validationReport = model.semanticReference.apply("`references/validation-r
 local reportVersusResult = model.semanticReference.apply(
   """
   The plan-file `## Validation Report` section is written separately using
-  `references/validation-report.md`. This file is the skill's return value to the
+  `references/validation-report.md`. This file is the phase's return value to the
   invoking workflow.
   """,
   """
@@ -32,7 +32,7 @@ local reportVersusResult = model.semanticReference.apply(
 /// workflow uses the same emitted document, so the reference remains unchanged.
 local validationResultHandoff = model.semanticReference.apply(
   """
-  The skill must return a Markdown result matching its validation result contract.
+  The phase must return a Markdown report matching its validation result contract.
   Branch on the report's `Status:`.
   """,
   "Branch on the report's `Status:`."
@@ -40,9 +40,9 @@ local validationResultHandoff = model.semanticReference.apply(
 local invoke = model.semanticReference.apply("Invoke", "Run")
 local invokedSkills = model.semanticReference.apply("invoked skills", "embedded phases")
 local invokedSkill = model.semanticReference.apply("invoked skill", "embedded phase")
-local markdownResult = model.semanticReference.apply("Markdown result", "internal state")
+local markdownResult = model.semanticReference.apply("Markdown report", "internal state")
 local returningValidationResult = model.semanticReference.apply("Returning one Markdown validation result", "Recording one Markdown validation result")
-local returnExactlyOneMarkdownResult = model.semanticReference.apply("Return exactly one Markdown result", "Set exactly one internal state")
+local returnExactlyOneMarkdownResult = model.semanticReference.apply("Return exactly one Markdown report", "Set exactly one internal state")
 local returnOnlyMarkdownReport = model.semanticReference.apply("Return only the Markdown report", "Record only the Markdown report")
 local returnLower = model.semanticReference.apply("return", "set internal status")
 local returnUpper = model.semanticReference.apply("Return", "Set internal status")
@@ -106,7 +106,7 @@ local renderCommandBody = (mode: model.WorkflowRenderMode) -> """
     summarize, or pre-scope it.
     
     Every `{plan-path}` and `{candidate-path}` emitted anywhere in this workflow is
-    the path carried by \(validation.render.apply(mode)) in its Markdown result (`Plan:`, or a
+    the path carried by \(validation.render.apply(mode)) in its Markdown report (`Plan:`, or a
     candidate path), so every emitted command is directly runnable.
     
     ## Workflow
@@ -137,7 +137,7 @@ local renderCommandBody = (mode: model.WorkflowRenderMode) -> """
     Do not rewrite it into a shorter summary. Do not drop the retry command. Do not
     add an alternate continuation that replaces `/validate`. Stop.
     
-    `validated` -> Print the complete validated Markdown result as returned.
+    `validated` -> Print the complete validated Markdown report as returned.
     Continue to the next step.
     
     ### 2. Report completion
@@ -182,7 +182,7 @@ local COMMAND = structuredCommand.render.apply("package", "").text
 
 local renderValidationSkillBody = (mode: model.WorkflowRenderMode) -> """
     \(model.packageOnlyBlock.apply("""
-    # SCE Validation
+    # Validation phase
     
     ## Purpose
     
@@ -260,8 +260,7 @@ local renderValidationSkillBody = (mode: model.WorkflowRenderMode) -> """
 
     When a check fails, record the failure and continue gathering evidence. Do not
     modify tests, application code, or configuration to make a check pass. Final
-    validation measures the finished work; repair belongs to a later work session,
-    not this skill.
+    validation measures the finished work; repair belongs to a normal work session outside this phase.
     
     Never report a check as passed unless it ran successfully or the authorized
     inspection confirmed the criterion.
@@ -429,7 +428,7 @@ local renderValidationReport = (mode: model.WorkflowRenderMode) -> """
 local VALIDATION_REPORT = renderValidationReport.apply("package")
 
 local renderValidationResult = (mode: model.WorkflowRenderMode) -> """
-    # Validation Result
+    # Validation report
     
     Return only one completed Markdown report using the applicable variant below.
     Do not include unused sections, placeholders, YAML, or a fenced code block.
@@ -442,7 +441,7 @@ local renderValidationResult = (mode: model.WorkflowRenderMode) -> """
     
     \(reportVersusResult.render.apply(mode))
     
-    ## Validated variant
+    ## Validated report
     
     # Validation Report
     
@@ -473,7 +472,7 @@ local renderValidationResult = (mode: model.WorkflowRenderMode) -> """
     
     ---
     
-    ## Failed variant
+    ## Failed report
     
     This variant is a session handoff. Another agent or a later session must be
     able to act from it alone. Write it as a prompt the user can paste forward, not
@@ -537,7 +536,7 @@ local renderValidationResult = (mode: model.WorkflowRenderMode) -> """
     
     ---
     
-    ## Blocked variant
+    ## Blocked report
     
     # Validation blocked
     

--- a/config/pkl/renderers/generation-contract-check.pkl
+++ b/config/pkl/renderers/generation-contract-check.pkl
@@ -289,8 +289,8 @@ local requiredHandoverSkillTokens = new Listing {
 }
 
 local requiredHandoverTemplateCompletenessTokens = new Listing {
-  "### Completeness contract"
-  "first four `##` sections shown in **Layout** are required"
+  "## Completeness contract"
+  "first four `##` sections shown in **Template** are required"
   "next `##` heading or the end of the"
   "empty list marker"
   "`{...}` placeholder"
@@ -329,10 +329,10 @@ local expectedExecutionContract = (allowsDecision: Boolean) ->
 
   Own this workflow from input through its terminal user-visible response.
   Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them.
-  Keep phase results internal and continue immediately until a defined wait or stop.
+  Keep internal phase results private and continue immediately until a defined wait or stop.
   Resume user waits in this same skill and session.
-  Use only the specified `references/output.md` layouts for gates and terminal
-  responses. Do not expose raw state or add text around a layout.
+  Render user-visible output only from the named workflow layouts or phase reports.
+  Do not expose raw internal state or add text around a rendered layout or report.
   Non-SCE helpers may assist, but must return to the active step without changing
   phase order, gates, waits, writes, validation, stops, or terminal output.
   """ + "\n" + if (allowsDecision)
@@ -346,9 +346,9 @@ local expectedExecutionContract = (allowsDecision: Boolean) ->
 local compactContractClauses = new Listing {
   "Own this workflow from input through its terminal user-visible response."
   "Follow its steps, gates, and stops in order; do not add, skip, reorder, or merge them."
-  "Keep phase results internal and continue immediately until a defined wait or stop."
+  "Keep internal phase results private and continue immediately until a defined wait or stop."
   "Resume user waits in this same skill and session."
-  "Use only the specified `references/output.md` layouts for gates and terminal\nresponses. Do not expose raw state or add text around a layout."
+  "Render user-visible output only from the named workflow layouts or phase reports.\nDo not expose raw internal state or add text around a rendered layout or report."
   "Non-SCE helpers may assist, but must return to the active step without changing\nphase order, gates, waits, writes, validation, stops, or terminal output."
 }
 
@@ -1128,7 +1128,7 @@ local validationExecutionPolicyTokens = new Listing {
   "Prefer the plan's authored checks."
   "Treat leftover debug-only flags, temporary files"
   "Never report a check as passed unless it ran successfully"
-  "repair belongs to a later work session"
+  "repair belongs to a normal work session outside this phase"
   "Do not reopen completed tasks, rewrite task evidence, or change the task stack."
 }
 
@@ -1198,7 +1198,38 @@ hidden assertValidateExcludesDecisionAndPlanSync = (documents: Mapping) ->
     ) "sce-validate package: no sce-decision reference or plan-context-sync wording"
     else throw("generated sce-validate document must not contain a sce-decision reference or plan-context-sync wording")
 
+
+hidden assertWorkflowLanguageConsistency = (artifacts: Mapping) ->
+  let (targets = new Listing { ".pi"; ".claude"; ".agents" })
+    if (
+      targets.every((target) ->
+        let (next = artifacts["config/\(target)/skills/sce-next-task/SKILL.md"])
+          let (commitRef = artifacts["config/\(target)/skills/sce-commit/references/atomic-commit.md"])
+            let (validationRef = artifacts["config/\(target)/skills/sce-validate/references/validation.md"])
+              let (handoverTemplate = artifacts["config/\(target)/skills/sce-handover/references/handover-template.md"])
+                let (planTemplate = artifacts["config/\(target)/skills/sce-change-to-plan/references/plan-template.md"])
+                  let (contextSync = artifacts["config/\(target)/skills/sce-next-task/references/context-sync.md"])
+                    next.contains("Keep internal phase results private")
+                    && next.contains("named workflow layouts or phase reports")
+                    && next.contains("**Implementation complete**")
+                    && commitRef.contains("# Atomic commit phase")
+                    && commitRef.contains("The phase is complete after:")
+                    && !commitRef.contains("Committing is not this skill's job")
+                    && validationRef.contains("# Validation phase")
+                    && validationRef.contains("# Validation report")
+                    && !validationRef.contains("# SCE Validation")
+                    && handoverTemplate.contains("# Handover document format")
+                    && handoverTemplate.contains("## Template")
+                    && handoverTemplate.contains("Include `Plan` when one plan is known")
+                    && planTemplate.contains("reports cleanup or repair work")
+                    && planTemplate.contains("it does not perform that work")
+                    && contextSync.contains("completed task with unresolved context synchronization")
+      )
+    ) "workflow language: shared vocabulary, phase naming, report naming, and document format are consistent"
+    else throw("generated workflow language/format drifted from the shared T11 conventions")
+
 contractChecks {
+  ["workflow-language-consistency"] = assertWorkflowLanguageConsistency.apply(generatedArtifacts)
   ["compact-execution-contracts"] = assertCompactExecutionContracts.apply(workflowDocuments)
   ["compact-execution-contract-negative-fixtures"] = assertCompactExecutionContractFixtures
   ["artifact-paths"] = assertExactArtifactPaths.apply(generatedArtifacts)

--- a/context/plans/compress-workflow-execution-preamble.md
+++ b/context/plans/compress-workflow-execution-preamble.md
@@ -452,3 +452,14 @@ The two additional root edits replace existing text without increasing line coun
     `nix run .#pkl-check-generated`, targeted ownership checks across all tracked
     mirrors, and `git diff --check`.
   - Context synchronization: synced.
+
+## Follow-up: workflow language and document consistency
+
+- [x] T11: `Normalize workflow language and document format` (status:done)
+  - Scope: shared workflow vocabulary, embedded-phase/reference wording, output/report terminology, plan-authoring tone, handover persisted-document format, validation non-repairing wording, canonical Pkl, generated Pi/Claude/Codex mirrors, semantic generation checks, and ownership context.
+  - Vocabulary after change: command = user invocation; workflow = complete procedure; phase = embedded operation; step = numbered action; internal result = structured private phase data; report = formatted Markdown; completion record = persisted task evidence; handover document = persisted session handover.
+  - Format after change: embedded references identify themselves as phases rather than sibling skills; persisted-format references use a document title plus Template/contract/rules sections; output headings use consistent sentence-case punctuation; output and validation prose distinguish internal results from rendered reports.
+  - Correctness fixes: `/validate` remains observational and reports cleanup/repair work instead of performing it; handover `Plan` and `Task` metadata are independently included only when known; context-sync recovery names completed tasks with unresolved synchronization; next-task calls the pre-validation terminal state `Implementation complete` rather than `Plan already complete`.
+  - Behavior preserved: command names, argument tokens, status values, approval gates, phase order, write permissions, persisted plan/task field names, decision qualification, and lifecycle transitions remain unchanged.
+  - Verify: `pkl eval config/pkl/renderers/generation-contract-check.pkl`; `nix run .#pkl-check-generated`; exact 141-artifact inventory; generated mirror parity; `git diff --check`; `workflow-language-consistency` semantic contract.
+  - Context synchronization: synced.

--- a/context/sce/dedup-ownership-table.md
+++ b/context/sce/dedup-ownership-table.md
@@ -43,3 +43,16 @@
 - Keep SCE workflow control flow inside the owning workflow skill. Relevant non-SCE skills may assist as in-step helpers that return control to the active step; `sce-decision` remains the sole SCE sibling-skill exception, usable only from successful task synchronization's decision gate, once per qualifying decision.
 - Do not reintroduce the removed `/validate` plan-context-sync handoff, legacy context-sync, or automated-profile Markdown ownership.
 - Do not reintroduce phase skills as a generated surface. Workflow behavior belongs in the canonical modules and installation belongs to the six command-routed workflow packages (see [Atomic commit workflow](atomic-commit-workflow.md) for `/commit`). The standalone `sce-decision` package is a separate internal surface, not a generated phase package or user-facing workflow.
+
+## Workflow language conventions
+
+- **Command** is the user-facing invocation such as `/next-task`.
+- **Workflow** is the complete procedure owned by a generated workflow `SKILL.md`.
+- **Phase** is an embedded operation such as plan review, task execution, or validation.
+- **Step** is one numbered action inside a workflow or phase.
+- **Internal result** is structured phase data that is not shown directly. Its discriminator is `status`.
+- **Report** is formatted Markdown shown to the user or persisted as a report section.
+- **Completion record** is execution evidence persisted on a completed task in its plan.
+- **Handover document** is the persisted session document under `context/handovers/`.
+
+Use the verbs consistently: run a phase, return an internal result, render a report or layout, and write a persisted file. Preserve distinct lifecycle terms such as task `done`, execution `complete`, context `synced`, and plan `validated`; do not collapse them into one generic success term.


### PR DESCRIPTION
Temporary verification PR for a clean T11. The verifier resets to the verified T10 head, applies canonical language/format normalization, regenerates only the five affected SCE workflow packages in tracked mirrors, runs generation contracts, and replaces this branch with one clean T11 commit.